### PR TITLE
Update MSA-DropDownMenu library to version 1.0.18

### DIFF
--- a/libs/MSA-DropDownMenu-1.0/DONTCOPY.txt
+++ b/libs/MSA-DropDownMenu-1.0/DONTCOPY.txt
@@ -1,1 +1,0 @@
-This library is a butchered version specifically tailored for Cross RP to avoid the stupid warning messages introduced in 8.0.

--- a/libs/MSA-DropDownMenu-1.0/MSA-DropDownMenu-1.0.lua
+++ b/libs/MSA-DropDownMenu-1.0/MSA-DropDownMenu-1.0.lua
@@ -1,16 +1,19 @@
 --- MSA-DropDownMenu-1.0 - DropDown menu for non-Blizzard addons
---- Copyright (c) 2016-2020, Marouan Sabbagh <mar.sabbagh@gmail.com>
+--- Copyright (c) 2016-2024, Marouan Sabbagh <mar.sabbagh@gmail.com>
 --- All Rights Reserved.
 ---
 --- https://www.curseforge.com/wow/addons/msa-dropdownmenu-10
 
-local name, version = "MSA-DropDownMenu-1.0", 12
+local name, version = "MSA-DropDownMenu-1.0", 18
 
-local lib, oldVersion = LibStub:NewLibrary(name, version)
+local lib = LibStub:NewLibrary(name, version)
 if not lib then return end
 
 -- WoW API
 local _G = _G
+
+-- Hack - Support of different WoW API versions
+local IsAddOnLoaded = C_AddOns.IsAddOnLoaded or IsAddOnLoaded;
 
 MSA_DROPDOWNMENU_MINBUTTONS = 8;
 MSA_DROPDOWNMENU_MAXBUTTONS = 8;
@@ -204,12 +207,7 @@ local function CreateDropDownList(name, parent)
     DropDownList:SetFrameStrata("DIALOG")
     DropDownList:EnableMouse(true)
 
-    local frame1
-    if oldVersion and oldVersion > 8 then  -- WoW 9.0 compatibility
-        frame1 = _G[name.."Backdrop"] or CreateFrame("Frame", name.."Backdrop", DropDownList, BackdropTemplateMixin and "BackdropTemplate")
-    else
-        frame1 = CreateFrame("Frame", name.."Backdrop", DropDownList, BackdropTemplateMixin and "BackdropTemplate")
-    end
+    local frame1 = _G[name.."Backdrop"] or CreateFrame("Frame", name.."Backdrop", DropDownList, "BackdropTemplate")
     frame1:SetAllPoints()
     frame1:SetBackdrop({
         bgFile = "Interface\\DialogFrame\\UI-DialogBox-Background-Dark",
@@ -225,12 +223,7 @@ local function CreateDropDownList(name, parent)
         },
     })
 
-    local frame2
-    if oldVersion and oldVersion > 8 then  -- WoW 9.0 compatibility
-        frame2 = _G[name.."MenuBackdrop"] or CreateFrame("Frame", name.."MenuBackdrop", DropDownList, BackdropTemplateMixin and "BackdropTemplate")
-    else
-        frame2 = CreateFrame("Frame", name.."MenuBackdrop", DropDownList, BackdropTemplateMixin and "BackdropTemplate")
-    end
+    local frame2 = _G[name.."MenuBackdrop"] or CreateFrame("Frame", name.."MenuBackdrop", DropDownList, "BackdropTemplate")
     frame2:SetAllPoints()
     frame2:SetBackdrop({
         bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
@@ -1439,7 +1432,7 @@ function MSA_ToggleDropDownMenu(level, value, dropDownFrame, anchorName, xOffset
 end
 
 if ToggleDropDownMenu then
-    hooksecurefunc("ToggleDropDownMenu", function(level, value, dropDownFrame, anchorName, xOffset, yOffset, menuList, button, autoHideDelay)
+    hooksecurefunc("ToggleDropDownMenu", function(level, value, dropDownFrame, anchorName, xOffset, yOffset, menuList, button, autoHideDelay, overrideDisplayMode)
         local listFrameMSA = _G["MSA_DropDownList1"];
         if ( listFrameMSA:IsShown() ) then
             listFrameMSA:Hide();
@@ -1588,7 +1581,11 @@ function MSA_DropDownMenuButton_OpenColorPicker(self, button)
         button = self;
     end
     MSA_DROPDOWNMENU_MENU_VALUE = button.value;
-    MSA_OpenColorPicker(button);
+    if WOW_PROJECT_ID ~= WOW_PROJECT_WRATH_CLASSIC then
+        ColorPickerFrame:SetupColorPickerAndShow(button);
+    else
+        MSA_OpenColorPicker(button);
+    end
 end
 
 function MSA_DropDownMenu_DisableButton(level, id)
@@ -1650,17 +1647,19 @@ function MSA_DropDownMenu_GetValue(id)
     end
 end
 
-function MSA_OpenColorPicker(info)
-    ColorPickerFrame.func = info.swatchFunc;
-    ColorPickerFrame.hasOpacity = info.hasOpacity;
-    ColorPickerFrame.opacityFunc = info.opacityFunc;
-    ColorPickerFrame.opacity = info.opacity;
-    ColorPickerFrame.previousValues = {r = info.r, g = info.g, b = info.b, opacity = info.opacity};
-    ColorPickerFrame.cancelFunc = info.cancelFunc;
-    ColorPickerFrame.extraInfo = info.extraInfo;
-    -- This must come last, since it triggers a call to ColorPickerFrame.func()
-    ColorPickerFrame:SetColorRGB(info.r, info.g, info.b);
-    ShowUIPanel(ColorPickerFrame);
+if WOW_PROJECT_ID == WOW_PROJECT_WRATH_CLASSIC then
+    function MSA_OpenColorPicker(info)
+        ColorPickerFrame.func = info.swatchFunc;
+        ColorPickerFrame.hasOpacity = info.hasOpacity;
+        ColorPickerFrame.opacityFunc = info.opacityFunc;
+        ColorPickerFrame.opacity = info.opacity;
+        ColorPickerFrame.previousValues = {r = info.r, g = info.g, b = info.b, opacity = info.opacity};
+        ColorPickerFrame.cancelFunc = info.cancelFunc;
+        ColorPickerFrame.extraInfo = info.extraInfo;
+        -- This must come last, since it triggers a call to ColorPickerFrame.func()
+        ColorPickerFrame:SetColorRGB(info.r, info.g, info.b);
+        ShowUIPanel(ColorPickerFrame);
+    end
 end
 
 ------------------------------------------------------------------------------------------------------------------------
@@ -1701,8 +1700,8 @@ local function LoadSkin_Aurora()
     if not IsAddOnLoaded("Aurora") then return end
     local Skin = _G.Aurora.Skin
     for i = 1, MSA_DROPDOWNMENU_MAXLEVELS do
-        Skin.TooltipBackdropTemplate(_G["MSA_DropDownList"..i.."MenuBackdrop"])
-        Skin.TooltipBackdropTemplate(_G["MSA_DropDownList"..i.."Backdrop"])
+        Skin.FrameTypeFrame(_G["MSA_DropDownList"..i.."MenuBackdrop"])
+        Skin.FrameTypeFrame(_G["MSA_DropDownList"..i.."Backdrop"])
     end
 end
 


### PR DESCRIPTION
This PR updates the MSA-DropDownMenu library to the currently latest version (1.0.18) to resolve a Lua error on startup.

Resolves #19 